### PR TITLE
Set polyfills via core-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "baumeister",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "browserify": "^14.4.0",
     "browserify-incremental": "^3.1.1",
     "chalk": "^2.0.1",
+    "core-js": "^2.4.1",
     "cssnano": "^3.10.0",
     "del": "^3.0.0",
     "eslint-config-xo": "0.18.2",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,3 +1,4 @@
+import './polyfills';
 import $ from 'jquery';
 import {consoleErrorFix, ieViewportFix} from './base';
 

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -11,5 +11,5 @@ require('bootstrap-sass');
 $(() => {
 	consoleErrorFix();
 	ieViewportFix();
-	console.log('YaY, my first ES6-Module !!!!');
+	console.log('                     YaY, my first ES6-Module !!!!'.trimStart());
 });

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -11,5 +11,5 @@ require('bootstrap-sass');
 $(() => {
 	consoleErrorFix();
 	ieViewportFix();
-	console.log('                     YaY, my first ES6-Module !!!!'.trimStart());
+	console.log('YaY, my first ES6-Module !!!!');
 });

--- a/src/app/polyfills.js
+++ b/src/app/polyfills.js
@@ -9,9 +9,23 @@
  */
 
 /**
+  * ----------------------------------------------------------------------------
+  * Import each and every polyfill provided by core-js
+  * -----------------------------------------------------------------------------
+  * This is for the lazy ones and absolultely not recommend because it will
+  * increase your JS bundle by more than 120 kb (minified). Better check what
+  * your target browsers need (https://kangax.github.io/compat-table/es6/)
+  * and use partial imports like in the examples below.
+  */
+// import 'core-js';
+
+/**
  * ----------------------------------------------------------------------------
  * Promises. Needed for Internet Explorer  up to IE11
  * -----------------------------------------------------------------------------
+ * This polyfill alone will blow up your bundle size with more than 20 kb
+ * (minified). So please  don’t use that if your are targeting only browser
+ * which have Promises build in. See https://kangax.github.io/compat-table/es6/
  */
 import 'core-js/es6/promise';
 

--- a/src/app/polyfills.js
+++ b/src/app/polyfills.js
@@ -1,0 +1,142 @@
+/**
+ * This file includes polyfills which you may need.
+ * Please only add those you are actually using. Otherwise you’ll unnecessarily
+ * blow up the size of your JS bundle.
+ *
+ * You can add your own extra polyfills to this file:
+ * Check https://github.com/zloirock/core-js to see whats available.
+ *
+ */
+
+/**
+ * ----------------------------------------------------------------------------
+ * Promises. Needed for Internet Explorer  up to IE11
+ * -----------------------------------------------------------------------------
+ */
+import 'core-js/es6/promise';
+
+/**
+ * ----------------------------------------------------------------------------
+ * Additional ES6 polyfills
+ * -----------------------------------------------------------------------------
+ */
+
+/**
+ * Import all object methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-object how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/object';
+
+/**
+ * Import all function methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-function how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/function';
+
+/**
+ * Import all array methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-array how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/array';
+
+/**
+ * Import all string methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-string how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/string';
+
+/**
+ * Import all regexp methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-regexp how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/regexp';
+
+/**
+ * Import all number methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-number how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/number';
+
+/**
+ * Import all math methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-math how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/math';
+
+/**
+ * Import all date methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-date how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/date';
+
+/**
+ * Import all collection types.
+ * See https://github.com/zloirock/core-js#ecmascript-6-collections.
+ */
+// import 'core-js/es6/map';
+// import 'core-js/es6/set';
+// import 'core-js/es6/weak-map';
+// import 'core-js/es6/weak-set';
+
+/**
+ * Import all typed-array methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-typed-arrays how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/typed';
+
+/**
+ * Import all reflect methods.
+ * See https://github.com/zloirock/core-js#ecmascript-6-reflect how to import
+ * just the ones you need.
+ */
+// import 'core-js/es6/reflect';
+
+/**
+ * ----------------------------------------------------------------------------
+ * Additional ES7+ polyfills
+ * -----------------------------------------------------------------------------
+ */
+
+/**
+ * Import all ES7 polyfills,
+ * See https://github.com/zloirock/core-js#ecmascript-7-proposals how to import
+ * just the ones you need.
+ */
+// import 'core-js/es7';
+
+/**
+ * Import all polyfills of stage 4 proposals
+ */
+// import 'core-js/stage/4';
+
+/**
+ * Import all polyfills of stage 3 proposals
+ * See https://github.com/zloirock/core-js#ecmascript-7-proposals how to import
+ * pre stage 3 polyfills.
+ */
+// import 'core-js/stage/3';
+
+/**
+ * ----------------------------------------------------------------------------
+ * Examples for method based imports
+ * -----------------------------------------------------------------------------
+ */
+
+/**
+ * Import a single string method
+ */
+// import 'core-js/fn/string/trim-start';
+
+/**
+ * Import a single array^ method
+ */
+// import 'core-js/fn/array/includes';

--- a/src/app/polyfills.js
+++ b/src/app/polyfills.js
@@ -134,7 +134,7 @@ import 'core-js/es6/promise';
 /**
  * Import a single string method
  */
-// import 'core-js/fn/string/trim-start';
+import 'core-js/fn/string/trim-start';
 
 /**
  * Import a single array^ method

--- a/src/app/polyfills.js
+++ b/src/app/polyfills.js
@@ -148,9 +148,9 @@ import 'core-js/es6/promise';
 /**
  * Import a single string method
  */
-import 'core-js/fn/string/trim-start';
+// import 'core-js/fn/string/trim-start';
 
 /**
- * Import a single array^ method
+ * Import a single array method
  */
 // import 'core-js/fn/array/includes';


### PR DESCRIPTION
This is how we could handle polyfills in Baumeister.

# Possible options

I’ve talked to @krnlde a while ago about the possibilities and drawbacks of [Babel runtime transform](https://babeljs.io/docs/plugins/transform-runtime/) and the [Babel polyfill](https://babeljs.io/docs/usage/polyfill/).

## 🚫 Babel runtime

It definitely has it use cases and advantages but there is a major drawback:
> Instance methods such as "foobar".includes("foo") will not work since that would require modification of existing built-ins (Use babel-polyfill for that).

So this is not an option if we like to use new methods.

## 🚫 Babel polyfill

The »no worries« solution also has it drawbacks:
- Blows up bundle size (125 kB minified)
- Pollutes the global scope

## ✅ core-js

Babel polyfill is just a thin wrapper around [core-js](https://github.com/zloirock/core-js#core-js).

Using core-js directly makes it possible to cherry pick and import just the polyfills you need to keep the JS bundle small.

Using the following at the top of our entrypoint 

```javascript
import './polyfills';
```
and »configuring« the imports in that file is almost as easy as using babel-polyfill.

This way we can use new stuff in the global stuff as well as instance methods. 

core-js also offers a way of using all this without adding stuff to the global scope, but this isn’t that handy to use.

---- 

Can I haz feedback?