### PR TITLE
fix: copy additional directories in src/assets to build directories

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -24,6 +24,7 @@ export const settings = {
 		scripts: ['./src/app/**/*.js'],
 		appTemplates: ['./src/app/**/*.html'],
 		images: ['./src/assets/img/**/*.{png,jpg,gif,svg}'],
+		assets: ['./src/assets/**/*', '!./src/assets/{fonts,fonts/**,img,img/**,scss,scss/**}'],
 		fonts: ['./src/assets/fonts/**/*'],
 		externalCss: configFile.bundleCSS,
 		externalJs: configFile.bundleExternalJS,
@@ -35,6 +36,7 @@ export const settings = {
 			html: `${mainDirectories.dev}`,
 			styles: `${mainDirectories.dev}assets/css/`,
 			app: `${mainDirectories.dev}app/`,
+			assets: `${mainDirectories.dev}assets/`,
 			fonts: `${mainDirectories.dev}assets/fonts/`,
 			images: `${mainDirectories.dev}assets/img/`,
 			libs: `${mainDirectories.dev}libs/`
@@ -43,6 +45,7 @@ export const settings = {
 			html: `${mainDirectories.dist}`,
 			styles: `${mainDirectories.dist}assets/css/`,
 			app: `${mainDirectories.dist}app/`,
+			assets: `${mainDirectories.dist}assets/`,
 			fonts: `${mainDirectories.dist}assets/fonts/`,
 			images: `${mainDirectories.dist}assets/img/`,
 			libs: `${mainDirectories.dist}libs/`

--- a/gulp/tasks/copy-assets.js
+++ b/gulp/tasks/copy-assets.js
@@ -1,0 +1,18 @@
+import gulp from 'gulp';
+
+import {settings} from '../config';
+import {isProdBuild} from '../command-line-args';
+
+/**
+ * Copy additional directories from src/assets
+ */
+function copyAssets() {
+	if (isProdBuild()) {
+		return gulp.src(settings.sources.assets)
+			.pipe(gulp.dest(settings.destinations.prod.assets));
+	}
+	return gulp.src(settings.sources.assets)
+		.pipe(gulp.dest(settings.destinations.dev.assets));
+}
+
+export default copyAssets;

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -16,6 +16,7 @@ import images from './gulp/tasks/images';
 import appTemplates from './gulp/tasks/app-templates';
 import {webpack, webpackWatch} from './gulp/tasks/webpack';
 import bundleExternalCSS from './gulp/tasks/bundle-external-css';
+import copyAssets from './gulp/tasks/copy-assets';
 import copyStaticFiles from './gulp/tasks/copy-static-files';
 import lint from './gulp/tasks/lint';
 import security from './gulp/tasks/security';
@@ -91,7 +92,7 @@ watch.description = '`gulp watch` watches for changes and runs tasks automatical
 export const build = gulp.series(
 	clean,
 	handlebars,
-	gulp.parallel(processHtml, appTemplates, lint, fonts, images, webpack, bundleExternalCSS, copyStaticFiles, validateHtml, lintBootstrap, lintStyles, security, test),
+	gulp.parallel(processHtml, appTemplates, lint, fonts, images, webpack, bundleExternalCSS, copyAssets, copyStaticFiles, validateHtml, lintBootstrap, lintStyles, security, test),
 	styles,
 	banners,
 	cacheBust


### PR DESCRIPTION
This makes it possible to place e.g. a download directory in src/assets