### PR TITLE
Enhance polyfills

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
 	"presets": ["env"],
 	"plugins": [
+		"syntax-dynamic-import",
 		"transform-object-rest-spread",
 		[
 			"transform-runtime",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,9 @@
 {
   "extends": "baumeister",
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "allowImportExportEverywhere": true
+},
   "overrides": [
     {
       "files": ["build/*.js"],

--- a/README.md
+++ b/README.md
@@ -624,11 +624,11 @@ We recommend using a command line tool like »[npm-check-update](https://github.
 
 ## Adding polyfills
 
-The file `src/app/base/polyfills.js` is prepared to import polyfills you might need depending on your use of modern JavaScript language features and your target browsers.
+The file `src/app/base/polyfills.js` is prepared to dynamic import polyfills you might need depending on your use of modern JavaScript language features and your target browsers. This way the polyfills are lazy loaded only in case the used browser actually needs them.
 
 Just import the ones you need for the browsers you are targeting.
 
-The only polyfill activated by default is a Promises polyfill which is needed if you use Promises and targeting Internet Explorers.
+The only polyfill activated by default is a Promises polyfill which is needed for lazy loading polyfills in Internet Explorers.
 
 ## Unit tests
 

--- a/build/webpack.dev.babel.js
+++ b/build/webpack.dev.babel.js
@@ -12,7 +12,8 @@ module.exports = require('./webpack.base.babel')({
 	},
 	output: {
 		path: path.join(__dirname, mainDirectories.dev),
-		filename: 'app/[name].bundle.js'
+		filename: 'app/[name].bundle.js',
+		chunkFilename: 'app/[name].bundle.js'
 	},
 	plugins: [
 		new webpack.SourceMapDevToolPlugin({

--- a/build/webpack.prod.babel.js
+++ b/build/webpack.prod.babel.js
@@ -40,7 +40,8 @@ module.exports = require('./webpack.base.babel')({
 	},
 	output: {
 		path: path.join(__dirname, mainDirectories.prod),
-		filename: configFile.cacheBusting ? 'app/[name].[chunkhash].bundle.js' : 'app/[name].bundle.js'
+		filename: configFile.cacheBusting ? 'app/[name].[chunkhash].bundle.js' : 'app/[name].bundle.js',
+		chunkFilename: configFile.cacheBusting ? 'app/[name].[chunkhash].bundle.js' : 'app/[name].bundle.js'
 	},
 	plugins: [
 		new UglifyJSPlugin({

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,56 @@
         "@babel/highlight": "7.0.0-beta.40"
       }
     },
+    "@babel/generator": {
+      "version": "7.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.42.tgz",
+      "integrity": "sha512-9x3zS4nG/6GAvJWB8fAK+5g/Di36xdubB43dMNSucNJTwPvmyfCippir/0I8zyG+ID66hLCLi8V9bomlWRYaHA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.42",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.5",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.42.tgz",
+      "integrity": "sha512-6IZ+kkPypwJrnmNzI3y31qAps2kXoPtCE241SvBva2YzB0n/YORWx2YM0jHPYOJBU9Xx5KkUhOKuWkeXZQgtTA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.42",
+        "@babel/template": "7.0.0-beta.42",
+        "@babel/types": "7.0.0-beta.42"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.42.tgz",
+      "integrity": "sha512-hF5KKcn+V/5PwU7KZ1aVwo535woLC9eV+djaoyNPZeMMJ2s+8bZlEa66Tarei0T68VRL5LXIs1Ao4hSabSkpBg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.42"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.42.tgz",
+      "integrity": "sha512-2r8pZG6SAJTTaI2OhxCmz5PKlMUPY5adOHrHtb1gM3ibJPDOzPAeOQNzItdxNnM33jjRakEGitXX6iYg7Sz73w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.42"
+      }
+    },
     "@babel/highlight": {
       "version": "7.0.0-beta.40",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
@@ -22,6 +72,126 @@
         "chalk": "2.3.1",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.42.tgz",
+      "integrity": "sha512-EK7YdTe47j4VxlwNvz5bnlk5Jx/wWublnqfgOY2IuSNdxCQgXrLD34PfTnabGxywNSkJkcSo6jwr2JGT+S48dA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.42",
+        "@babel/types": "7.0.0-beta.42",
+        "babylon": "7.0.0-beta.42",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.42",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz",
+          "integrity": "sha512-L8i94FLSyaLQpRfDo/qqSm8Ndb44zMtXParXo0MebJICG1zoCCL4+GkzUOlB4BNTRSXXQdb3feam/qw7bKPipQ==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.42"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.42",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.42.tgz",
+          "integrity": "sha512-X3Ur/A/lIbbP8W0pmwgqtDXIxhQmxPaiwY9SKP7kF9wvZfjZRwMvbJE92ozUhF3UDK3DCKaV7oGqmI1rP/zqWA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.42",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.42.tgz",
+          "integrity": "sha512-h6E/OkkvcBw/JimbL0p8dIaxrcuQn3QmIYGC/GtJlRYif5LTKBYPHXYwqluJpfS/kOXoz0go+9mkmOVC0M+zWw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.42.tgz",
+      "integrity": "sha512-DZwMuZBfYVIn/cxpXZzHDgKmarW/MWqplLv1k7QJYhK5r5l6GAac/DkKl75A0CjPYrD3VGco6H6ZQp12QaYKSw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.42",
+        "@babel/generator": "7.0.0-beta.42",
+        "@babel/helper-function-name": "7.0.0-beta.42",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.42",
+        "@babel/types": "7.0.0-beta.42",
+        "babylon": "7.0.0-beta.42",
+        "debug": "3.1.0",
+        "globals": "11.3.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.42",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz",
+          "integrity": "sha512-L8i94FLSyaLQpRfDo/qqSm8Ndb44zMtXParXo0MebJICG1zoCCL4+GkzUOlB4BNTRSXXQdb3feam/qw7bKPipQ==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.42"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.42",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.42.tgz",
+          "integrity": "sha512-X3Ur/A/lIbbP8W0pmwgqtDXIxhQmxPaiwY9SKP7kF9wvZfjZRwMvbJE92ozUhF3UDK3DCKaV7oGqmI1rP/zqWA==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.42",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.42.tgz",
+          "integrity": "sha512-h6E/OkkvcBw/JimbL0p8dIaxrcuQn3QmIYGC/GtJlRYif5LTKBYPHXYwqluJpfS/kOXoz0go+9mkmOVC0M+zWw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.42.tgz",
+      "integrity": "sha512-+pmpISmTHQqMMpHHtDLxcvtRhmn53bAxy8goJfHipS/uy/r3PLcuSdPizLW7DhtBWbtgIKZufLObfnIMoyMNsw==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -709,6 +879,28 @@
         "source-map": "0.5.7"
       }
     },
+    "babel-eslint": {
+      "version": "8.2.2",
+      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+      "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.40",
+        "@babel/traverse": "7.0.0-beta.42",
+        "@babel/types": "7.0.0-beta.42",
+        "babylon": "7.0.0-beta.42",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.42",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.42.tgz",
+          "integrity": "sha512-h6E/OkkvcBw/JimbL0p8dIaxrcuQn3QmIYGC/GtJlRYif5LTKBYPHXYwqluJpfS/kOXoz0go+9mkmOVC0M+zWw==",
+          "dev": true
+        }
+      }
+    },
     "babel-generator": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
@@ -928,6 +1120,12 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
       "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
@@ -5085,7 +5283,7 @@
       "dependencies": {
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         }
@@ -5721,7 +5919,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15028,6 +15028,11 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.0.tgz",
+      "integrity": "sha512-P6NJ2wU/8fac44ENORsuqT8TiolKGB2u0fEClPtXezn7w5cmLIjM/7mhPlTebke2EPr6tmqZbXvnX0TxwykGrg=="
+    },
     "property-is-enumerable-x": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-eslint": "^8.2.1",
     "babel-loader": "^7.1.2",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,10 @@
   },
   "dependencies": {
     "bootstrap": "^4.0.0",
+    "core-js": "^2.5.3",
     "jquery": "^3.3.1",
     "popper.js": "^1.12.9",
-    "core-js": "^2.5.3"
+    "promise-polyfill": "^7.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/app/base/polyfills.js
+++ b/src/app/base/polyfills.js
@@ -21,13 +21,18 @@
 
 /**
  * ----------------------------------------------------------------------------
- * Promises. Needed for Internet Explorer  up to IE11
+ * Promises. Mainly needed for Internet Explorer up to IE11
  * -----------------------------------------------------------------------------
- * This polyfill alone will blow up your bundle size with more than 20 kb
- * (minified). So please  don’t use that if your are targeting only browsers
- * which have Promises build in. See https://kangax.github.io/compat-table/es6/
+ * Promises are needed to lazy load addtional polyfills in case there are
+ * needed. We are using https://github.com/taylorhakes/promise-polyfill instead
+ * of the polyfill provided by core-js to keep the vendor bundle as small as
+ * possible. This one adds 3.19 kB minified and 1.23 kB minified and gzipped.
+ *
+ * But remember that you don’t have to use it if your are targeting only
+ * browsers which have Promises build in.
+ * See https://kangax.github.io/compat-table/es6/
  */
-import 'core-js/es6/promise';
+import 'promise-polyfill/src/polyfill';
 
 /**
  * ----------------------------------------------------------------------------

--- a/src/app/base/polyfills.js
+++ b/src/app/base/polyfills.js
@@ -3,27 +3,19 @@
  * Please only add those you are actually using. Otherwise you’ll unnecessarily
  * blow up the size of your JS bundle.
  *
- * You can add your own extra polyfills to this file:
- * Check https://github.com/zloirock/core-js to see whats available.
+ * You can add your own additional polyfills to this file:
+ * See https://github.com/zloirock/core-js to see whats available.
  *
+ * Check what your target browsers need (https://kangax.github.io/compat-table/es6/)
+ * and use dynamic imports like in the examples below. This way the polyfills
+ * are lazy loaded only when a browser actually needs them.
  */
-
-/**
-  * ----------------------------------------------------------------------------
-  * Import each and every polyfill provided by core-js
-  * -----------------------------------------------------------------------------
-  * This is for the lazy ones and absolultely not recommended because it will
-  * increase your JS bundle by more than 120 kb (minified). Better check what
-  * your target browsers need (https://kangax.github.io/compat-table/es6/)
-  * and use partial imports like in the examples below.
-  */
-// import 'core-js';
 
 /**
  * ----------------------------------------------------------------------------
  * Promises. Mainly needed for Internet Explorer up to IE11
  * -----------------------------------------------------------------------------
- * Promises are needed to lazy load addtional polyfills in case there are
+ * Promises are needed to lazy load additional polyfills in case there are
  * needed. We are using https://github.com/taylorhakes/promise-polyfill instead
  * of the polyfill provided by core-js to keep the vendor bundle as small as
  * possible. This one adds 3.19 kB minified and 1.23 kB minified and gzipped.
@@ -36,126 +28,61 @@ import 'promise-polyfill/src/polyfill';
 
 /**
  * ----------------------------------------------------------------------------
- * Additional ES6 polyfills
+ * Definition of dynamically imported polyfills
  * -----------------------------------------------------------------------------
  */
 
-/**
- * Import all object methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-object how to import
- * just the ones you need.
- */
-// import 'core-js/es6/object';
+export const applyPolyfills = () => {
 
-/**
- * Import all function methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-function how to import
- * just the ones you need.
- */
-// import 'core-js/es6/function';
+	const polyfills = [];
 
-/**
- * Import all array methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-array how to import
- * just the ones you need.
- */
-// import 'core-js/es6/array';
+	/**
+	 * Globals
+	 */
 
-/**
- * Import all string methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-string how to import
- * just the ones you need.
- */
-// import 'core-js/es6/string';
+	// if (typeof Object.assign !== 'function') {
+	// 	polyfills.push(import(/* webpackChunkName: "Object.assign" */ 'core-js/fn/object/assign'));
+	// }
 
-/**
- * Import all regexp methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-regexp how to import
- * just the ones you need.
- */
-// import 'core-js/es6/regexp';
+	// if (!window.Set) {
+	// 	polyfills.push(import(/* webpackChunkName: "set" */ 'core-js/es6/set'));
+	// }
 
-/**
- * Import all number methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-number how to import
- * just the ones you need.
- */
-// import 'core-js/es6/number';
+	// if (!window.Map) {
+	// 	polyfills.push(import(/* webpackChunkName: "map" */ 'core-js/es6/map'));
+	// }
 
-/**
- * Import all math methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-math how to import
- * just the ones you need.
- */
-// import 'core-js/es6/math';
+	/**
+	 * Array prototype methods
+	 */
 
-/**
- * Import all date methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-date how to import
- * just the ones you need.
- */
-// import 'core-js/es6/date';
+	// if (!Array.prototype.includes) {
+	// 	polyfills.push(import(/* webpackChunkName: "Array.prototype.includes" */ 'core-js/fn/array/includes'));
+	// }
 
-/**
- * Import all collection types.
- * See https://github.com/zloirock/core-js#ecmascript-6-collections.
- */
-// import 'core-js/es6/map';
-// import 'core-js/es6/set';
-// import 'core-js/es6/weak-map';
-// import 'core-js/es6/weak-set';
+	// if (!Array.prototype.find) {
+	// 	polyfills.push(import(/* webpackChunkName: "Array.prototype.find" */ 'core-js/fn/array/find'));
+	// }
 
-/**
- * Import all typed-array methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-typed-arrays how to import
- * just the ones you need.
- */
-// import 'core-js/es6/typed';
+	/**
+	 * String prototype methods
+	 */
 
-/**
- * Import all reflect methods.
- * See https://github.com/zloirock/core-js#ecmascript-6-reflect how to import
- * just the ones you need.
- */
-// import 'core-js/es6/reflect';
+	// if (!String.prototype.includes) {
+	// 	polyfills.push(import(/* webpackChunkName: "String.prototype.includes" */ 'core-js/fn/string/includes'));
+	// }
 
-/**
- * ----------------------------------------------------------------------------
- * Additional ES7+ polyfills
- * -----------------------------------------------------------------------------
- */
+	// if (!String.prototype.startsWith) {
+	// 	polyfills.push(import(/* webpackChunkName: "String.prototype.startsWith" */ 'core-js/fn/string/starts-with'));
+	// }
 
-/**
- * Import all ES7 polyfills,
- * See https://github.com/zloirock/core-js#ecmascript-7-proposals how to import
- * just the ones you need.
- */
-// import 'core-js/es7';
+	// if (!String.prototype.trimStart) {
+	// 	polyfills.push(import(/* webpackChunkName: "String.prototype.trimStart" */ 'core-js/fn/string/trim-start'));
+	// }
 
-/**
- * Import all polyfills of stage 4 proposals
- */
-// import 'core-js/stage/4';
+	// if (!String.prototype.trimEnd) {
+	// 	polyfills.push(import(/* webpackChunkName: "String.prototype.trimEnd" */ 'core-js/fn/string/trim-end'));
+	// }
 
-/**
- * Import all polyfills of stage 3 proposals
- * See https://github.com/zloirock/core-js#ecmascript-7-proposals how to import
- * pre stage 3 polyfills.
- */
-// import 'core-js/stage/3';
-
-/**
- * ----------------------------------------------------------------------------
- * Examples for method based imports
- * -----------------------------------------------------------------------------
- */
-
-/**
- * Import a single string method
- */
-// import 'core-js/fn/string/trim-start';
-
-/**
- * Import a single array method
- */
-// import 'core-js/fn/array/includes';
+	return Promise.all(polyfills);
+};

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -10,7 +10,7 @@ import 'bootstrap';
 // import 'bootstrap/js/dist/dropdown';
 
 // Import polyfills
-import './base/polyfills';
+import {applyPolyfills} from './base/polyfills';
 
 // Import methods from the base module
 import {consoleErrorFix, ieViewportFix} from './base/base';
@@ -18,8 +18,12 @@ import {consoleErrorFix, ieViewportFix} from './base/base';
 // Import our Sass entrypoint to create the CSS app bundle
 import '../assets/scss/index.scss';
 
-$(() => {
+$(async () => {
+	// Wait with further execution until needed polyfills are loaded.
+	await applyPolyfills();
+
 	consoleErrorFix();
 	ieViewportFix();
+
 	console.log('YaY, my first ES6-Module !!!!');
 });


### PR DESCRIPTION
* refactor: switch to promise-polyfill 
   * This replaces the promise polyfill from core-js to keep the vendor bundle as small as possible.
* feature: Dynamically import and lazy load polyfills 
   * this keeps the vendor bundle in modern browser smaller because polyfills are only loaded when the used browser actually needs them.