### PR TITLE
refactor: Use CLI options to generate test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "build:serve": "serve dist --open",
     "build:analyze": "npm run webpack:stats --silent && webpack-bundle-analyzer ./.webpack-stats.json ./dist -s parsed",
     "pretest": "npm run eslint --silent",
-    "test": "cross-env NODE_ENV=test jest",
-    "test:watch": "npm run test -- --watch",
+    "test": "cross-env NODE_ENV=test jest --coverage",
+    "test:watch": "npm run test:coverage -- --watch",
+    "test:coverage": "cross-env NODE_ENV=test jest --coverage",
     "eslint": "eslint --ext .jsx,.js --cache build src",
     "eslint:fix": "npm run eslint --silent -- --fix",
     "eslint:watch": "onchange \"src/**/*.js\" \"src/**/*.jsx\" \"build/**/*.js\" -- onerror \"npm run eslint --silent\" -t \"Linting error(s)\"",
@@ -117,7 +118,6 @@
       "<rootDir>/build/",
       "<rootDir>/node_modules/"
     ],
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "src/app/**/*.{js,jsx}",
       "!**/node_modules/**"


### PR DESCRIPTION
In the next major release `npm test` will run tests without generating coverage reports.

For now `npm test` and `npm run test:coverage` will do the same. This is to prevent a breaking change and will be updated with the next major release. Feel free to change this in your project setup.