### PR TITLE
feat: Auto format code using prettier as pre-commit hook

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "baumeister",
+  "extends": ["baumeister", "prettier", "prettier/unicorn", "prettier/react"],
   "parser": "babel-eslint",
   "parserOptions": {
     "allowImportExportEverywhere": true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+# See https://prettier.io/docs/en/options.html for available options
+printWidth: 100
+singleQuote: true
+jsxBracketSameLine: true

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,20 +3,23 @@
   "rules": {
     "indentation": "tab",
     "number-leading-zero": ["always", { "severity": "warning" }],
-    "at-rule-no-unknown": [true, {
-      "ignoreAtRules": [
-        "extend",
-        "mixin",
-        "include",
-        "at-root",
-        "debug",
-        "warn",
-        "error",
-        "if",
-        "for",
-        "each",
-        "while"
-      ]
-    }]
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": [
+          "extend",
+          "mixin",
+          "include",
+          "at-root",
+          "debug",
+          "warn",
+          "error",
+          "if",
+          "for",
+          "each",
+          "while"
+        ]
+      }
+    ]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 dist: trusty
 language: node_js
 node_js:
-  - 6
   - 8
+  - 10
   - node
 script:
   - npm run build

--- a/README.md
+++ b/README.md
@@ -16,22 +16,23 @@ Baumeister is here to help you to build your things. From Bootstrap themes over 
 
 - a file structure with focus on maintainability and upgradability
 - a build setup based on webpack and npm scripts with the following »features«
-	- generate static sites with ease using handlebars templates
-		- optional – see [details](#writing-markup-static-sites-vs-single-page-apps)
-	- transpile, bundle and minify your code
-		- ES6 as well as Sass
-	- visualize size of bundled files with an interactive zoomable treemap
-	- remove `console` output and `debugger` statements in production files
-	- add vendor prefixes
-	- lint JavaScript, Sass and HTML
-	- optimize images (lossless)
-	- start a local server
-	- delete unused CSS (optional)
-	- check for known vulnerabilities in dependencies
-	- release new versions
-	- run unit tests and create coverage reports
-	- web performance optimization fundamentals 
-	- and more.
+  - generate static sites with ease using handlebars templates
+    - optional – see [details](#writing-markup-static-sites-vs-single-page-apps)
+  - transpile, bundle and minify your code
+    - ES6 as well as Sass
+  - visualize size of bundled files with an interactive zoomable treemap
+  - remove `console` output and `debugger` statements in production files
+  - add vendor prefixes
+  - lint JavaScript, Sass and HTML
+  - optimize images (lossless)
+  - start a local server
+  - delete unused CSS (optional)
+  - check for known vulnerabilities in dependencies
+  - release new versions
+  - run unit tests and create coverage reports
+  - web performance optimization fundamentals
+  - automatically format code
+  - and more.
 
 Baumeister mainly uses [webpack](https://webpack.js.org) at its core for transpiling, bundling and minifying files and provides [npm scripts](#build-workflow-and-npm-scripts) for working with the project. Besides that we have defined a few npm scripts to handle things like our [release workflow](#release-workflow). All necessary dependencies are installed locally via npm.
 
@@ -49,6 +50,7 @@ Baumeister mainly uses [webpack](https://webpack.js.org) at its core for transpi
 - [Unit tests](#unit-tests)
 - [Configuring linters](#configuring-linters)
 - [Web performance optimization](#web-performance-optimization)
+- [Automatic code formatting](#automatic-code-formatting)
 - [Adding banners](#adding-banners)
 - [Release Workflow](#release-workflow)
 - [Contributing to this project](#contributing-to-this-project)
@@ -59,23 +61,24 @@ Baumeister mainly uses [webpack](https://webpack.js.org) at its core for transpi
 For those already using Node.js.
 
 ### via Yeoman
-*See: <https://github.com/micromata/generator-baumeister> for details.*
 
-	$ npm i -g yo
-	$ npm i -g generator-baumeister
-	$ yo baumeister
-	$ npm start
+_See: <https://github.com/micromata/generator-baumeister> for details._
 
-*See [Build Workflow and npm scripts](#build-workflow-and-npm-scripts) for the main scripts.*
+    $ npm i -g yo
+    $ npm i -g generator-baumeister
+    $ yo baumeister
+    $ npm start
+
+_See [Build Workflow and npm scripts](#build-workflow-and-npm-scripts) for the main scripts._
 
 ### via Git
 
-	$ git clone https://github.com/micromata/baumeister.git
-	$ cd baumeister
-	$ npm install
-	$ npm start
+    $ git clone https://github.com/micromata/baumeister.git
+    $ cd baumeister
+    $ npm install
+    $ npm start
 
-*See [Build Workflow and npm scripts](#build-workflow-and-npm-scripts) for the main scripts.*
+_See [Build Workflow and npm scripts](#build-workflow-and-npm-scripts) for the main scripts._
 
 ## Dependencies
 
@@ -89,7 +92,7 @@ Please enter the following in your terminal if you aren’t sure about the avail
 
 ```
 node --version
-````
+```
 
 This should return something like the following in case Node.js and npm is already installed:
 
@@ -123,46 +126,46 @@ In the root directory is a file named `baumeister.json` which can be used to cha
 
 ```json
 {
-  "useHandlebars": true,
-  "purifyCSS": {
-    "usePurifyCSS": false,
-    "whitelist": [
-      "*navbar*",
-      "*modal*",
-      "*dropdown*",
-      "*carousel*",
-      "*tooltip*",
-      "open",
-      "fade",
-      "collapse",
-      "collapsing",
-      "in"
-    ]
-  },
-  "generateBanners": false,
-  "cacheBusting": true,
-  "vendor": {
-    "bundleCSS": [],
-    "includeStaticFiles": []
-  },
-  "webpack": {
-    "DefinePlugin": {
-      "development": {
-        "PRODUCTION": false
-      },
-      "production": {
-        "PRODUCTION": true
-      }
-    },
-    "ProvidePlugin": {
-      "$": "jquery",
-      "jQuery": "jquery"
-    }
-  }
+	"useHandlebars": true,
+	"purifyCSS": {
+		"usePurifyCSS": false,
+		"whitelist": [
+			"*navbar*",
+			"*modal*",
+			"*dropdown*",
+			"*carousel*",
+			"*tooltip*",
+			"open",
+			"fade",
+			"collapse",
+			"collapsing",
+			"in"
+		]
+	},
+	"generateBanners": false,
+	"cacheBusting": true,
+	"vendor": {
+		"bundleCSS": [],
+		"includeStaticFiles": []
+	},
+	"webpack": {
+		"DefinePlugin": {
+			"development": {
+				"PRODUCTION": false
+			},
+			"production": {
+				"PRODUCTION": true
+			}
+		},
+		"ProvidePlugin": {
+			"$": "jquery",
+			"jQuery": "jquery"
+		}
+	}
 }
 ```
 
-`vendor.bundleCSS` and `vendor.includeStaticFiles` make it possible to include additional dependencies without touching any webpack config. These settings are explained in depth in the section  [Using external libraries](#using-external-libraries) within this document.
+`vendor.bundleCSS` and `vendor.includeStaticFiles` make it possible to include additional dependencies without touching any webpack config. These settings are explained in depth in the section [Using external libraries](#using-external-libraries) within this document.
 
 The ramifications of changing the `useHandlebars` setting are explained in the section [Writing markup (static sites vs. single page apps)](#writing-markup-static-sites-vs-single-page-apps).
 
@@ -172,7 +175,7 @@ The ramifications of changing the `useHandlebars` setting are explained in the s
 
 If you want to provide constants for different types of builds, you can define them inside the `development` and `production` properties of the `DefinePlugin` section.
 
-The plugin does a direct text replacement, so the value given to it must include actual quotes inside of the string. You can use alternating quotes, like `"'My value'"`, or  use `JSON.stringify('My value')`.
+The plugin does a direct text replacement, so the value given to it must include actual quotes inside of the string. You can use alternating quotes, like `"'My value'"`, or use `JSON.stringify('My value')`.
 
 This is very useful to change the behavior between development and production build. For example adapting the URL prefix to an API. This is why we have predefined the constant `PRODUCTION` in `baumeister.json`.
 
@@ -187,26 +190,25 @@ See the official [webpack ProvidePlugin docs](https://webpack.js.org/plugins/def
 
 Once you complete the setup, you'll be able to run various npm scripts from the command line. The main scripts needed for developing and building your project are listed below.
 
-| Command                 | Description |
-| ----------------------- | --- |
-| `npm start`             | *Builds for development, starts a webserver, watches files for changes, rebuilds incrementally and reloads your browser.* |
-| `npm test`              | *Lints your JavaScript files and runs unit tests via the Jest CLI.* |
-| `npm run test:watch`    | *Runs unit test with Jests watch option.* |
-| `npm run build`         | *Builds for production to `dist` directory.* |
-| `npm run build:serve`   | *Starts a static fileserver serving the `dist` directory.* |
-| `npm run build:analyze` | *Starts »webpack bundle analyzer« to visualize size of webpack output files* |
+| Command                 | Description                                                                                                               |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `npm start`             | _Builds for development, starts a webserver, watches files for changes, rebuilds incrementally and reloads your browser._ |
+| `npm test`              | _Lints your JavaScript files and runs unit tests via the Jest CLI._                                                       |
+| `npm run test:watch`    | _Runs unit test with Jests watch option._                                                                                 |
+| `npm run build`         | _Builds for production to `dist` directory._                                                                              |
+| `npm run build:serve`   | _Starts a static fileserver serving the `dist` directory._                                                                |
+| `npm run build:analyze` | _Starts »webpack bundle analyzer« to visualize size of webpack output files_                                              |
 
-
->**🔥 Tip:**  
->There a lot more scripts defined in the `package.json`, but most of the other ones are used to combine scripts. Therefore we have set up an interactive CLI menu to list and run the most importants npm scripts via:
+> **🔥 Tip:**  
+> There a lot more scripts defined in the `package.json`, but most of the other ones are used to combine scripts. Therefore we have set up an interactive CLI menu to list and run the most importants npm scripts via:
 >
->```
->$ npm run tasks
->```
+> ```
+> $ npm run tasks
+> ```
 
 Running those scripts will create a bunch of directories and files which aren’t under version control. Do not be concerned if you see these resources:
 
-````
+```
 myProject
 ├──.metalsmith-build                → Compiled handlebars sources
 ├── coverage                        → Test coverage reports
@@ -222,16 +224,18 @@ myProject
 ├── .eslintcache
 ├── .webpack-assets.json            → Contains bundled file names
 └── .webpack-stats.json             → Contains bundle information
-````
+```
 
 ## Setting up your Editor
 
 We strongly advise installing an [EditorConfig plugin](http://editorconfig.org/#download) and taking a look at the `.editorconfig` file in the root of this project.
 
 ## Writing Markup (static sites vs. single page apps)
+
 Baumeister acts like a static site generator by default. Using handlebars we can simplify our templates and avoid markup duplications by using a combination of `pages`, `layouts` and `partials`.
 
 ### This is optional
+
 Using Handlebars instead of plain HTML is fully optional and will probably suit your needs if you use Baumeister for creating a static site. If you are developing a single page application instead it would be a good idea to turn off handlebars compiling, place an `index.html` file in the `/src` directory, and store additional templates in `/src/app`.
 
 In this case you have to switch off Handlebars compiling in `baumeister.json`:
@@ -345,20 +349,20 @@ Content of `index.html`:
 ```html
 <!DOCTYPE html>
 <html>
-<head>
-	<meta charset="utf-8">
-	<title>My Project - My page title</title>
-	<link rel="stylesheet" href="">
-</head>
-<body>
-	<h1>My page</h1>
+	<head>
+		<meta charset="utf-8" />
+		<title>My Project - My page title</title>
+		<link rel="stylesheet" href="" />
+	</head>
+	<body>
+		<h1>My page</h1>
 
-	<p>My content</p>
+		<p>My content</p>
 
-	<footer>
-		© 2017 MyCompany
-	</footer>
-</body>
+		<footer>
+			© 2017 MyCompany
+		</footer>
+	</body>
 </html>
 ```
 
@@ -372,7 +376,7 @@ title: My page title
 ---
 ```
 
-Frontmatters are basically a key/value storage you can access within your layouts, pages and partials via Handlebars.  This empowers you to do things like [handling active states](https://github.com/micromata/baumeister/blob/master/src/handlebars/partials/navbar.hbs#L16-L22) of your navigation and much more.
+Frontmatters are basically a key/value storage you can access within your layouts, pages and partials via Handlebars. This empowers you to do things like [handling active states](https://github.com/micromata/baumeister/blob/master/src/handlebars/partials/navbar.hbs#L16-L22) of your navigation and much more.
 
 There is one predefined key which let you choose a different layout file in case you’re using more than one:
 
@@ -402,19 +406,19 @@ src/assets/scss
     └── _testResponsiveHelpers.scss
 ```
 
-
 There seems to be a pretty huge amount of files for such a small project. So here we go with an explanation.
 
 ### index.scss
+
 Our main Sass file is the one which is creating our index.css file. This file just has a few imports.
 
 ```scss
 // Import our variables to override Bootstraps default ones
-@import "./variables";
+@import './variables';
 
 // Bootstrap Core
 // --------------------------------------------------
-@import "../../../node_modules/bootstrap/scss/bootstrap";
+@import '../../../node_modules/bootstrap/scss/bootstrap';
 
 /**
  * --------------------------------------------------
@@ -423,7 +427,7 @@ Our main Sass file is the one which is creating our index.css file. This file ju
 
 // Theme
 // --------------------------------------------------
-@import "./theme";
+@import './theme';
 
 // Print Styles
 // --------------------------------------------------
@@ -431,10 +435,9 @@ Our main Sass file is the one which is creating our index.css file. This file ju
 // @import "./print";
 
 ////////// Do NOT insert style-definitions here! //////////
-
 ```
 
-### _theme.scss
+### \_theme.scss
 
 We use this file to import the modules/files which defines the actual theme. You could also use this to write down your styles and omit using separate files in the corresponding folder `theme`. But we recommend not doing that. See content of `_theme.scss`:
 
@@ -442,14 +445,14 @@ We use this file to import the modules/files which defines the actual theme. You
 // Override and extend Bootstrap stuff
 // --------------------------------------------------
 // Files, classes, mixins etc.
-@import "theme/mixins";
-@import "theme/scaffolding";
-@import "theme/alerts";
+@import 'theme/mixins';
+@import 'theme/scaffolding';
+@import 'theme/alerts';
 
 // Own modules
 // --------------------------------------------------
 // @import "theme/testResponsiveHelpers"; // debug
-@import "theme/footer";
+@import 'theme/footer';
 
 // Important note //
 // You could also use this file to insert theme related style definitions
@@ -482,21 +485,19 @@ This folder holds the modules needed by the theme. The skeleton of such a module
 
 	// Styles
 	//
-
 }
-
 ```
 
-See [_footer.sass](src/assets/scss/theme/_footer.scss) for a »real life« example.
+See [\_footer.sass](src/assets/scss/theme/_footer.scss) for a »real life« example.
 
 There are three files which differ from regular components. Please have a look at comments within the following files to get an idea how to handle them:
 
-- [_variables.scss](src/assets/scss/_variables.scss)
-	Used to override bootstrap variables. Make sure to read the comments which describe how to handle this file which can save you lots of time when it comes to a Bootstrap update.
-- [_mixins.scss](src/assets/scss/theme/_mixins.scss)
-	Holds additional global mixins which are meant to be used across modules.
-- [_scaffolding.scss](src/assets/scss/theme/_scaffolding.scss)
-	Used to define the most generic html elements.
+- [\_variables.scss](src/assets/scss/_variables.scss)
+  Used to override bootstrap variables. Make sure to read the comments which describe how to handle this file which can save you lots of time when it comes to a Bootstrap update.
+- [\_mixins.scss](src/assets/scss/theme/_mixins.scss)
+  Holds additional global mixins which are meant to be used across modules.
+- [\_scaffolding.scss](src/assets/scss/theme/_scaffolding.scss)
+  Used to define the most generic html elements.
 
 ## Using external libraries
 
@@ -504,8 +505,8 @@ Let’s assume you'd like to add some fanciness to your form select fields. This
 
 This is how you get the files into your `/node_modules` directory and define the dependency in the `package.json` file.
 
-	cd path/to/your/checkout/of/baumeister
-	npm search select2
+    cd path/to/your/checkout/of/baumeister
+    npm search select2
 
 This leads to something like:
 
@@ -520,7 +521,7 @@ vue-select                | A native Vue.js…     | =sagalbot       | 2017-03-1
 
 where the Name is your key for installation. In our use case you would do:
 
-	npm install --save select2
+    npm install --save select2
 
 which will:
 
@@ -534,8 +535,8 @@ which will:
 import 'select2';
 
 $(() => {
-  // Using select2
-  $('.single-select').select2();
+	// Using select2
+	$('.single-select').select2();
 });
 ```
 
@@ -662,6 +663,7 @@ You can watch changes and run tests automatically with:
 ```
 npm run test:watch
 ```
+
 This comes in handy since it’s blazingly fast. It only run tests related to changed files per default but has an interactive mode which enables you to run all if needed.
 
 ### For those who are new to Jest
@@ -673,10 +675,11 @@ Placing tests in `__tests__` directories is a default feature from Jest.
 You can adjust the name of your tests-directory with the `testDirectoryName` configuration option.
 
 The most important things to know:
+
 - [API docs](https://facebook.github.io/jest/docs/api.html)
 - [Assertions](https://facebook.github.io/jest/docs/expect.html)
 
-*You are not forced to use Jests assertions. You can alternatively use `assert` by just requiring it or installing and using Chai.*
+_You are not forced to use Jests assertions. You can alternatively use `assert` by just requiring it or installing and using Chai._
 
 We strongly recommend checking the [docs](https://facebook.github.io/jest/docs/getting-started.html) to dive deeper and read for instance how Jest can help you with mocking.
 
@@ -695,7 +698,6 @@ Feel free to deactivate or change the rules according to your needs here:
 ```
 
 See [Configuring ESLint](http://eslint.org/docs/user-guide/configuring) if you need to know more.
-
 
 ### stylelint (Sass)
 
@@ -725,7 +727,7 @@ For example. `["button-active", "*modal*"]` will leave any selector that include
 
 #### Alternative: selective imports
 
-You could also import just the CSS from Bootstrap that you actually need in your project in `src/assets/scss/index.scss`. But you won‘t get your CSS bundle size that small in comparison to PurifyCSS. 
+You could also import just the CSS from Bootstrap that you actually need in your project in `src/assets/scss/index.scss`. But you won‘t get your CSS bundle size that small in comparison to PurifyCSS.
 
 ### Make use of long-term caching
 
@@ -741,7 +743,7 @@ You can disable hash based file name revving by setting the `cacheBusting` prope
 
 ### Selective JavaScript imports
 
-Some libraries, such as react-bootstrap and lodash, are rather large and pulling in the entire module just to use a few pieces would cause unnecessary bloat to your JavaScript vendor bundle. 
+Some libraries, such as react-bootstrap and lodash, are rather large and pulling in the entire module just to use a few pieces would cause unnecessary bloat to your JavaScript vendor bundle.
 
 `babel-plugin-transform-imports` can be used to add only what you need to your bundle. It automatically transforms member style imports such as:
 
@@ -761,6 +763,23 @@ import merge from 'lodash/merge';
 Check the [packages page](https://www.npmjs.com/package/babel-plugin-transform-imports#thats-stupid-why-would-you-do-that) to read about the why.
 
 Baumeister has already set up the plugin for `lodash`, `reactstrap`, `react-bootstrap` and `react-router` just in case you will use them. See `src/app/.babelrc` to add aditional libraries.
+
+## Automatic code formatting
+
+We are using [prettier](https://prettier.io) to format JavaScript, JSON and SCSS files automatically before you commit your files to Git via a pre-commit hook.
+
+The prettier settings are defined in `.prettierrc` in the project root. In case prettier is to opinated for you or you don’t want Prettier to change your files without the chance to review the changes you just have to delete the pre-commit hook with in the `package.json`:
+
+```json
+"husky": {
+  "hooks": {
+    "post-merge": "npm install",
+    "pre-commit": "lint-staged"
+  }
+}
+```
+
+But we totally recommend you to give this workflow a chance, because it’s just one more thing you don’t have to care about.
 
 ## Adding banners
 
@@ -793,22 +812,24 @@ We provide the following npm scripts to automate releases:
 ```
 npm run release:patch
 ```
+
 ```
 npm run release:minor
 ```
+
 ```
 npm run release:major
 ```
 
 See <http://semver.org> for details of when to choose which release type.
 
-As long as your git commit messages are [conventional](https://conventionalcommits.org)  and accurate, you no longer need to specify the semver type. You can just use the following instead:
+As long as your git commit messages are [conventional](https://conventionalcommits.org) and accurate, you no longer need to specify the semver type. You can just use the following instead:
+
 ```
 npm run release
 ```
 
-*This script can also be used to define pre-releases by adding the optional flags like `npm run release -- --prerelease beta`. See [Release as a pre-release](https://github.com/conventional-changelog/standard-version/blob/master/README.md#release-as-a-pre-release) for further information.*
-
+_This script can also be used to define pre-releases by adding the optional flags like `npm run release -- --prerelease beta`. See [Release as a pre-release](https://github.com/conventional-changelog/standard-version/blob/master/README.md#release-as-a-pre-release) for further information._
 
 All release scripts will:
 
@@ -849,13 +870,17 @@ See the last [commits](https://github.com/micromata/baumeister/commits) of Baume
 #### Short summary of the conventions
 
 Example commit message:
+
 ```
 fix(uglify): Remove console output and debugger statements
 ```
+
 Consists of:
+
 ```
 type(scope): subject
 ```
+
 ##### Types
 
 Types are used to group commits in the changelog.
@@ -870,6 +895,7 @@ The scope is optional and you can choose from whatever you want.
 The scope is used as another grouping element below the type.
 
 You can skip the parentheses if you don’t want to use Scope:
+
 ```
 style: Fix linting errors
 ```
@@ -878,15 +904,16 @@ style: Fix linting errors
 
 The subject contains a succinct description of the change:
 
-* use the imperative, present tense: "change" not "changed" nor "changes"
-* capitalize first letter
-* don't add a dot (.) at the end
+- use the imperative, present tense: "change" not "changed" nor "changes"
+- capitalize first letter
+- don't add a dot (.) at the end
 
-##### Additional Info,  Breaking changes and issue references
+##### Additional Info, Breaking changes and issue references
 
 These are defined in the body of the commit message.
 
 Example:
+
 ```
 feat(build): Replace Gulp with webpack and npm scripts
 <BLANK LINE>
@@ -895,6 +922,7 @@ BREAKING CHANGE: Gulp tasks aren’t available any longer.
 But there are equivalent npm scripts.
 List the available scripts with `npx nls`
 ```
+
 The body can include the motivation for the change and contrast this with previous behavior.
 
 Plus it should contain any information about **Breaking Changes** and is also the place to
@@ -912,9 +940,9 @@ https://github.com/micromata/Baumeister/blob/master/CHANGELOG.md
 Anyone and everyone is welcome to contribute. Please take a moment to
 review our [Code of Conduct](CODE_OF_CONDUCT.md) as well as our [guidelines for contributing](CONTRIBUTING.md).
 
-* [Bug reports](CONTRIBUTING.md#bugs)
-* [Feature requests](CONTRIBUTING.md#features)
-* [Pull requests](CONTRIBUTING.md#pull-requests)
+- [Bug reports](CONTRIBUTING.md#bugs)
+- [Feature requests](CONTRIBUTING.md#features)
+- [Pull requests](CONTRIBUTING.md#pull-requests)
 
 ## License
 

--- a/build/config.js
+++ b/build/config.js
@@ -3,12 +3,12 @@ const configFile = require('../baumeister.json');
 /**
  * Boolean flag to set when using handlebars instead of plain HTML files in `src`.
  */
-export const {useHandlebars} = configFile;
+export const { useHandlebars } = configFile;
 
 /**
  * Flag for generating banners on on top of dist files (CSS & JS).
  */
-export const {generateBanners} = configFile;
+export const { generateBanners } = configFile;
 
 export const mainDirectories = {
 	dev: '../server/',

--- a/build/handlebars.js
+++ b/build/handlebars.js
@@ -10,9 +10,9 @@ import registerPartials from 'metalsmith-discover-partials';
 import filter from 'metalsmith-filter';
 import globby from 'globby';
 import perfy from 'perfy';
-import {stripIndents} from 'common-tags';
+import { stripIndents } from 'common-tags';
 
-import {settings, useHandlebars} from './config';
+import { settings, useHandlebars } from './config';
 
 perfy.start('build', false);
 
@@ -31,37 +31,44 @@ metalsmith(__dirname)
 	.clean(true)
 
 	// Register Handlebars helpers
-	.use(registerHelpers({
-		directory: path.join(__dirname, '../', settings.sources.handlebars, 'helpers')
-	}))
+	.use(
+		registerHelpers({
+			directory: path.join(__dirname, '../', settings.sources.handlebars, 'helpers')
+		})
+	)
 
 	// Register Handlebars partials
-	.use(registerPartials({
-		directory: path.join(__dirname, '../', settings.sources.handlebars, 'partials'),
-		pattern: /\.hbs$/
-	}))
+	.use(
+		registerPartials({
+			directory: path.join(__dirname, '../', settings.sources.handlebars, 'partials'),
+			pattern: /\.hbs$/
+		})
+	)
 
 	// Wrap layouts around content pages
-	.use(layouts({
-		directory: path.join(__dirname, '../', settings.sources.handlebars, 'layouts'),
-		default: 'default.hbs',
-		pattern: '**/*.hbs'
-	}))
+	.use(
+		layouts({
+			directory: path.join(__dirname, '../', settings.sources.handlebars, 'layouts'),
+			default: 'default.hbs',
+			pattern: '**/*.hbs'
+		})
+	)
 
 	// Render handlebars content pages
-	.use(inPlace({
-		engineOptions: {
-			pattern: '*.hbs',
-			partials: path.join(__dirname, '../', settings.sources.handlebars, 'partials')
-		}
-	}))
+	.use(
+		inPlace({
+			engineOptions: {
+				pattern: '*.hbs',
+				partials: path.join(__dirname, '../', settings.sources.handlebars, 'partials')
+			}
+		})
+	)
 
 	// Only build HTML files
 	.use(filter(['**/*.html', 'handlebars']))
 
 	// Finally build files
 	.build(err => {
-
 		// Handle build errors
 		if (err) {
 			console.log(stripIndents`
@@ -69,36 +76,38 @@ metalsmith(__dirname)
 				${chalk.red.bold(err.message)}
 			`);
 			process.exit(1);
-
-		// Handle successful build
 		} else {
+			// Handle successful build
 			/**
 			 * NOTE:
 			 * We need to backdate the generated files by ten seconds until
 			 * https://github.com/webpack/watchpack/issues/25 is fixed.
-			 * Otherwise we would have some uneeded rebuilds when starting webpack in
+			 * Otherwise we would have some unneeded rebuilds when starting webpack in
 			 * watch mode or starting the webpack dev server.
 			 */
 			const f = path.resolve(__dirname, '../', settings.destinations.handlebars);
 			const now = Date.now() / 1000;
 			const then = now - 10;
-			globby(f + '/**/*.html')
-				.then(files => {
-					files.forEach(file => {
-						fs.utimes(file, then, then, (err) => {
-							if (err) {
-								console.error(err);
-							}
+			globby(f + '/**/*.html').then(files => {
+				files.forEach(file => {
+					fs.utimes(file, then, then, err => {
+						if (err) {
+							console.error(err);
+						}
 
-							console.log(
-								logSymbols.success,
-								`Finished ${chalk.blue.bold('Handlebars build')} after`,
-								chalk.yellow.bold(perfy.end('build').time >= 1 ? `${Math.round(perfy.end('build').time * 100) / 100} s` : `${Math.round(perfy.end('build').milliseconds)} ms`),
-								'\n'
-							);
-							process.exit(0);
-						});
+						console.log(
+							logSymbols.success,
+							`Finished ${chalk.blue.bold('Handlebars build')} after`,
+							chalk.yellow.bold(
+								perfy.end('build').time >= 1
+									? `${Math.round(perfy.end('build').time * 100) / 100} s`
+									: `${Math.round(perfy.end('build').milliseconds)} ms`
+							),
+							'\n'
+						);
+						process.exit(0);
 					});
 				});
+			});
 		}
 	});

--- a/build/webpack.config.babel.js
+++ b/build/webpack.config.babel.js
@@ -1,22 +1,24 @@
 import chalk from 'chalk';
 import minimist from 'minimist';
-import {stripIndents} from 'common-tags';
+import { stripIndents } from 'common-tags';
 
-import {isDevMode} from './webpack/helpers';
-import {devServer} from './webpack/config.dev-server';
-import {entry} from './webpack/config.entry';
-import {rules} from './webpack/config.module.rules';
-import {output} from './webpack/config.output';
-import {plugins} from './webpack/config.plugins';
-import {optimization} from './webpack/config.optimization';
-import {stats} from './webpack/config.stats';
+import { isDevMode } from './webpack/helpers';
+import { devServer } from './webpack/config.dev-server';
+import { entry } from './webpack/config.entry';
+import { rules } from './webpack/config.module.rules';
+import { output } from './webpack/config.output';
+import { plugins } from './webpack/config.plugins';
+import { optimization } from './webpack/config.optimization';
+import { stats } from './webpack/config.stats';
 
 const cliFlags = minimist(process.argv.slice(2));
 const buildTarget = isDevMode() ? ' Development ' : ' Production ';
 
 if (!cliFlags.json) {
-	console.log(chalk.yellow(stripIndents`Build target: ${chalk.bold.inverse(buildTarget)}
-	━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`));
+	console.log(
+		chalk.yellow(stripIndents`Build target: ${chalk.bold.inverse(buildTarget)}
+	━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
+	);
 }
 
 module.exports = {
@@ -27,7 +29,7 @@ module.exports = {
 	 */
 	devtool: isDevMode() ? 'inline-cheap-module-source-map' : false,
 	entry,
-	module: {rules},
+	module: { rules },
 	output,
 	plugins,
 	optimization,

--- a/build/webpack/config.dev-server.js
+++ b/build/webpack/config.dev-server.js
@@ -1,11 +1,13 @@
 import path from 'path';
 
-import {mainDirectories} from '../config';
-import {isDevMode} from './helpers';
-import {stats} from './config.stats';
+import { mainDirectories } from '../config';
+import { isDevMode } from './helpers';
+import { stats } from './config.stats';
 
 export const devServer = {
-	contentBase: isDevMode() ? path.join(__dirname, '../', mainDirectories.dev) : path.join(__dirname, '../', mainDirectories.prod),
+	contentBase: isDevMode()
+		? path.join(__dirname, '../', mainDirectories.dev)
+		: path.join(__dirname, '../', mainDirectories.prod),
 	port: isDevMode() ? 3000 : 3001,
 	overlay: true,
 	stats: {

--- a/build/webpack/config.entry.js
+++ b/build/webpack/config.entry.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import globby from 'globby';
-import {settings} from '../config';
+import { settings } from '../config';
 
 const configFile = require('../../baumeister.json');
 
@@ -11,11 +11,12 @@ export const entry = {
 
 function getVendorCSS() {
 	// Return flattened array of resolved globs from baumeister.json
-	const vendorCSS = [].concat(...configFile.vendor.bundleCSS.map(glob => globby.sync(`./node_modules/${glob}`)));
+	const vendorCSS = [].concat(
+		...configFile.vendor.bundleCSS.map(glob => globby.sync(`./node_modules/${glob}`))
+	);
 	if (!vendorCSS.length) {
 		return false;
 	}
 
-	return {vendor: vendorCSS};
+	return { vendor: vendorCSS };
 }
-

--- a/build/webpack/config.module.rules.js
+++ b/build/webpack/config.module.rules.js
@@ -1,8 +1,8 @@
 import path from 'path';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
-import {settings} from '../config';
-import {isDevMode} from './helpers';
+import { settings } from '../config';
+import { isDevMode } from './helpers';
 
 const configFile = require('../../baumeister.json');
 
@@ -11,49 +11,40 @@ export const rules = [
 		test: /\.(js|jsx)$/,
 		include: path.resolve(__dirname, '../../', settings.sources.app),
 		exclude: /(node_modules)/,
-		loader: 'babel-loader', options: {
+		loader: 'babel-loader',
+		options: {
 			sourceMap: isDevMode()
 		}
 	},
 	{
 		test: /\.css$/,
-		use: [
-			MiniCssExtractPlugin.loader,
-			'css-loader'
-		]
+		use: [MiniCssExtractPlugin.loader, 'css-loader']
 	},
 	{
 		test: /\.scss$/,
 		use: [
-			(MiniCssExtractPlugin.loader),
-			{loader: 'css-loader', options: {sourceMap: isDevMode()}},
+			MiniCssExtractPlugin.loader,
+			{ loader: 'css-loader', options: { sourceMap: isDevMode() } },
 			{
-				loader: 'postcss-loader', options:
-						{
-							sourceMap: isDevMode(),
-							config: {
-								ctx: {
-									usePurifyCSS: configFile.purifyCSS.usePurifyCSS,
-									cssnano: {
-										discardComments: {
-											removeAll: true
-										}
-									},
-									autoprefixer: {
-										browsers: [
-											'> 1%',
-											'last 3 version',
-											'ie 8',
-											'ie 9',
-											'Firefox ESR',
-											'Opera 12.1'
-										]
-									}
+				loader: 'postcss-loader',
+				options: {
+					sourceMap: isDevMode(),
+					config: {
+						ctx: {
+							usePurifyCSS: configFile.purifyCSS.usePurifyCSS,
+							cssnano: {
+								discardComments: {
+									removeAll: true
 								}
+							},
+							autoprefixer: {
+								browsers: ['> 1%', 'last 3 version', 'ie 8', 'ie 9', 'Firefox ESR', 'Opera 12.1']
 							}
 						}
+					}
+				}
 			},
-			{loader: 'sass-loader', options: {sourceMap: isDevMode()}}
+			{ loader: 'sass-loader', options: { sourceMap: isDevMode() } }
 		]
 	},
 	{

--- a/build/webpack/config.output.js
+++ b/build/webpack/config.output.js
@@ -1,12 +1,16 @@
 import path from 'path';
-import {mainDirectories} from '../config';
-import {isDevMode} from './helpers';
+import { mainDirectories } from '../config';
+import { isDevMode } from './helpers';
 
 const configFile = require('../../baumeister.json');
 
 export const output = {
-	path: isDevMode() ? path.join(__dirname, '../', mainDirectories.dev) : path.join(__dirname, '../', mainDirectories.prod),
+	path: isDevMode()
+		? path.join(__dirname, '../', mainDirectories.dev)
+		: path.join(__dirname, '../', mainDirectories.prod),
 	filename: configFile.cacheBusting ? 'app/[name].[chunkhash].bundle.js' : 'app/[name].bundle.js',
-	chunkFilename: configFile.cacheBusting ? 'app/[name].[chunkhash].bundle.js' : 'app/[name].bundle.js',
+	chunkFilename: configFile.cacheBusting
+		? 'app/[name].[chunkhash].bundle.js'
+		: 'app/[name].bundle.js',
 	publicPath: '/'
 };

--- a/build/webpack/config.plugins.js
+++ b/build/webpack/config.plugins.js
@@ -1,15 +1,15 @@
 import path from 'path';
 import webpack from 'webpack';
 import globby from 'globby';
-import {stripIndents} from 'common-tags';
+import { stripIndents } from 'common-tags';
 import WebpackAssetsManifest from 'webpack-assets-manifest';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import PurifyCSSPlugin from 'purifycss-webpack';
 import ImageminPlugin from 'imagemin-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
-import {generateBanners, settings, useHandlebars} from '../config';
-import {isDevMode, isProdMode} from './helpers';
+import { generateBanners, settings, useHandlebars } from '../config';
+import { isDevMode, isProdMode } from './helpers';
 
 const pkg = require('../../package.json');
 const configFile = require('../../baumeister.json');
@@ -30,7 +30,7 @@ const purifyCSSOptions = {
 	paths: globby.sync(path.join(settings.destinations.handlebars, '**/*.html')),
 	purifyOptions: {
 		minify: true,
-		cleanCssOptions: {level: {1: {specialComments: 0}}},
+		cleanCssOptions: { level: { 1: { specialComments: 0 } } },
 		whitelist: configFile.purifyCSS.whitelist
 	}
 };
@@ -41,9 +41,12 @@ const purifyCSSOptions = {
 const generalPlugins = [
 	manifest,
 	new MiniCssExtractPlugin({
-		filename: configFile.cacheBusting && isProdMode() ? 'assets/css/[name].[chunkhash].bundle.css' : 'assets/css/[name].bundle.css'
+		filename:
+			configFile.cacheBusting && isProdMode()
+				? 'assets/css/[name].[chunkhash].bundle.css'
+				: 'assets/css/[name].bundle.css'
 	}),
-	new webpack.ProvidePlugin({...configFile.webpack.ProvidePlugin}),
+	new webpack.ProvidePlugin({ ...configFile.webpack.ProvidePlugin }),
 	new CopyWebpackPlugin([
 		{
 			from: '**/*.html',
@@ -54,7 +57,9 @@ const generalPlugins = [
 						return `<!-- No ${$1} to be bundled -->`;
 					}
 
-					return /\.css/g.test($1) ? `<link href="/${manifest.assets[$1]}" rel="stylesheet">` : `<script src="/${manifest.assets[$1]}"></script>`;
+					return /\.css/g.test($1)
+						? `<link href="/${manifest.assets[$1]}" rel="stylesheet">`
+						: `<script src="/${manifest.assets[$1]}"></script>`;
 				});
 			}
 		},
@@ -66,7 +71,11 @@ const generalPlugins = [
 		},
 		...copyVendorFiles
 	]),
-	new webpack.DefinePlugin(isDevMode() ? {...configFile.webpack.DefinePlugin.development} : {...configFile.webpack.DefinePlugin.production})
+	new webpack.DefinePlugin(
+		isDevMode()
+			? { ...configFile.webpack.DefinePlugin.development }
+			: { ...configFile.webpack.DefinePlugin.production }
+	)
 ];
 
 /**
@@ -79,14 +88,18 @@ const devPlugins = [];
  */
 const prodPlugins = [
 	new webpack.HashedModuleIdsPlugin(),
-	new ImageminPlugin({test: /\.(jpe?g|png|gif|svg)$/i}),
+	new ImageminPlugin({ test: /\.(jpe?g|png|gif|svg)$/i }),
 	configFile.purifyCSS.usePurifyCSS ? new PurifyCSSPlugin(purifyCSSOptions) : false,
-	generateBanners ? new webpack.BannerPlugin({
-		banner: stripIndents`${pkg.title} - v${pkg.version}
+	generateBanners
+		? new webpack.BannerPlugin({
+				banner: stripIndents`${pkg.title} - v${pkg.version}
 		${pkg.author.email}
 		Copyright ©${new Date().getFullYear()} ${pkg.author.name}
-		${new Date().toLocaleDateString('en-US', {day: '2-digit', month: 'long', year: 'numeric'})}`
-	}) : false
+		${new Date().toLocaleDateString('en-US', { day: '2-digit', month: 'long', year: 'numeric' })}`
+		  })
+		: false
 ].filter(Boolean);
 
-export const plugins = isDevMode() ? [...generalPlugins, ...devPlugins] : [...generalPlugins, ...prodPlugins];
+export const plugins = isDevMode()
+	? [...generalPlugins, ...devPlugins]
+	: [...generalPlugins, ...prodPlugins];

--- a/build/webpack/helpers.js
+++ b/build/webpack/helpers.js
@@ -1,7 +1,7 @@
-export const isDevMode = function () {
+export const isDevMode = function() {
 	return process.env.NODE_ENV === 'development';
 };
 
-export const isProdMode = function () {
+export const isProdMode = function() {
 	return process.env.NODE_ENV === 'production';
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -798,6 +798,83 @@
       "integrity": "sha512-gzAiePolEXlMlQxbHWcdmz+b+PEixO5so0mU8jMlCemp8sxUWko9AzWc4EK3MV6BCUYd9cjq+Gd477cZiq5Kfw==",
       "dev": true
     },
+    "@iamstarkov/listr-update-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz",
+      "integrity": "sha512-IJyxQWsYDEkf8C8QthBn5N8tIUR9V9je6j3sMIpAkonaadjbvxmRC6RAhpa3RKxndhNnU2M6iNbtJwd7usQYIA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -813,6 +890,15 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
+    },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      }
     },
     "@sindresorhus/is": {
       "version": "0.7.0",
@@ -1314,6 +1400,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
       "dev": true
     },
     "anymatch": {
@@ -3013,6 +3105,59 @@
         "string-width": "^2.1.1"
       }
     },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -4431,6 +4576,12 @@
         }
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -4609,6 +4760,12 @@
           "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -5243,6 +5400,12 @@
       "integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==",
       "dev": true
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "elliptic": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
@@ -5490,6 +5653,15 @@
         "eslint-plugin-import": "^2.16.0",
         "eslint-plugin-security": "^1.4.0",
         "eslint-plugin-unicorn": "^7.1.0"
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.0.0.tgz",
+      "integrity": "sha512-kWuiJxzV5NwOwZcpyozTzDT5KJhBw292bbYro9Is7BWnbNMg15Gmpluc1CTetiCatF8DRkNvgPAOaSyg+bYr3g==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
       }
     },
     "eslint-config-xo": {
@@ -6545,6 +6717,12 @@
         "pkg-dir": "^2.0.0"
       }
     },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -6628,6 +6806,12 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "fn-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.6.1",
@@ -7360,6 +7544,17 @@
       "integrity": "sha1-3/yA9tawQiPyImqnndGUIxCW0Ag=",
       "dev": true
     },
+    "g-status": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/g-status/-/g-status-2.0.2.tgz",
+      "integrity": "sha512-kQoE9qH+T1AHKgSSD0Hkv98bobE90ILQcXAF4wvGgsr7uFqNvwmh8j+Lq3l0RVt3E3HjSbv2B9biEGcEtpHLCA==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "matcher": "^1.0.0",
+        "simple-git": "^1.85.0"
+      }
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -7426,6 +7621,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
       "dev": true
     },
     "get-pkg-repo": {
@@ -9446,6 +9647,23 @@
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
+        }
+      }
+    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -10529,6 +10747,185 @@
         "type-check": "~0.3.2"
       }
     },
+    "lint-staged": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.3.tgz",
+      "integrity": "sha512-6TGkikL1B+6mIOuSNq2TV6oP21IhPMnV8q0cf9oYZ296ArTVNcbFh1l1pfVOHHbBIYLlziWNsQ2q45/ffmJ4AA==",
+      "dev": true,
+      "requires": {
+        "@iamstarkov/listr-update-renderer": "0.4.1",
+        "chalk": "^2.3.1",
+        "commander": "^2.14.1",
+        "cosmiconfig": "^5.0.2",
+        "debug": "^3.1.0",
+        "dedent": "^0.7.0",
+        "del": "^3.0.0",
+        "execa": "^1.0.0",
+        "find-parent-dir": "^0.3.0",
+        "g-status": "^2.0.2",
+        "is-glob": "^4.0.0",
+        "is-windows": "^1.0.2",
+        "listr": "^0.14.2",
+        "lodash": "^4.17.5",
+        "log-symbols": "^2.2.0",
+        "micromatch": "^3.1.8",
+        "npm-which": "^3.0.1",
+        "p-map": "^1.1.1",
+        "path-is-inside": "^1.0.2",
+        "pify": "^3.0.0",
+        "please-upgrade-node": "^3.0.2",
+        "staged-git-files": "1.1.2",
+        "string-argv": "^0.0.2",
+        "stringify-object": "^3.2.2",
+        "yup": "^0.26.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        }
+      }
+    },
+    "listr": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+      "dev": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
+          "integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==",
+          "dev": true
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
+      }
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -10713,6 +11110,29 @@
       "dev": true,
       "requires": {
         "chalk": "^2.0.1"
+      }
+    },
+    "log-update": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          }
+        }
       }
     },
     "logalot": {
@@ -11031,6 +11451,15 @@
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
       "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
       "dev": true
+    },
+    "matcher": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+      "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.4"
+      }
     },
     "mathml-tag-names": {
       "version": "2.1.0",
@@ -12055,6 +12484,15 @@
         "pify": "^3.0.0"
       }
     },
+    "npm-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.10"
+      }
+    },
     "npm-run-all": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
@@ -12079,6 +12517,17 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
       }
     },
     "npmlog": {
@@ -13557,6 +14006,12 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "24.0.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.0.0.tgz",
@@ -13628,6 +14083,12 @@
         "kleur": "^3.0.2",
         "sisteransi": "^1.0.0"
       }
+    },
+    "property-expr": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
+      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==",
+      "dev": true
     },
     "proto-list": {
       "version": "1.2.4",
@@ -15323,6 +15784,15 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "simple-git": {
+      "version": "1.107.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.107.0.tgz",
+      "integrity": "sha512-t4OK1JRlp4ayKRfcW6owrWcRVLyHRUlhGd0uN6ZZTqfDq8a5XpcUdOKiGRNobHEuMtNqzp0vcJNvhYWwh5PsQA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.0.1"
+      }
+    },
     "simple-output": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-output/-/simple-output-1.0.1.tgz",
@@ -15807,6 +16277,12 @@
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.2.tgz",
+      "integrity": "sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==",
+      "dev": true
+    },
     "standard-version": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.4.0.tgz",
@@ -16173,6 +16649,12 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string-argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
+      "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
+      "dev": true
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -16223,6 +16705,17 @@
         "character-entities-legacy": "^1.0.0",
         "is-alphanumerical": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -16566,6 +17059,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
+    "synchronous-promise": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.6.tgz",
+      "integrity": "sha512-TyOuWLwkmtPL49LHCX1caIwHjRzcVd62+GF6h8W/jHOeZUFHpnd2XJDVuUlaTaLPH1nuu2M69mfHr5XbQJnf/g==",
       "dev": true
     },
     "table": {
@@ -17111,6 +17610,12 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
       "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
+      "dev": true
+    },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=",
       "dev": true
     },
     "tough-cookie": {
@@ -18642,6 +19147,31 @@
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "yup": {
+      "version": "0.26.10",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.26.10.tgz",
+      "integrity": "sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "7.0.0",
+        "fn-name": "~2.0.1",
+        "lodash": "^4.17.10",
+        "property-expr": "^1.5.0",
+        "synchronous-promise": "^2.0.5",
+        "toposort": "^2.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+          "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "http://www.micromata.de"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.6"
   },
   "license": "MIT",
   "version": "3.1.0",
@@ -46,7 +46,11 @@
     "clean": "del .webpack-assets.json dist",
     "clean:dev": "del .webpack-assets.json server",
     "tasks": "ntl -d -o",
-    "postinstall": "chalk -t '{green Installed Baumeister successfully.\n{white Run} {yellow npm run tasks} {white to list and run the most importants npm scripts.}}'"
+    "postinstall": "chalk -t '{green Installed Baumeister successfully.\n{white Run} {yellow npm run tasks} {white to list and run the most importants npm scripts.}}'",
+    "prettier": "prettier",
+    "prettier:write": "npm run prettier --silent -- --write",
+    "prettier:write:all": "npm run prettier --silent -- --write \"{{src,build}/**/*.{js,json,scss},./*.{js,json}}\"",
+    "prettier:check:all": "npm run prettier --silent -- --check \"{{src,build}/**/*.{js,json,scss},./*.{js,json}}\""
   },
   "ntl": {
     "descriptions": {
@@ -87,6 +91,7 @@
     "del-cli": "^1.1.0",
     "eslint": "^5.13.0",
     "eslint-config-baumeister": "^1.2.0",
+    "eslint-config-prettier": "^4.0.0",
     "eslint-config-xo": "^0.26.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.16.0",
@@ -98,6 +103,7 @@
     "imagemin-webpack-plugin": "^2.1.1",
     "jest-cli": "^24.1.0",
     "jstransformer-handlebars": "^1.1.0",
+    "lint-staged": "^8.1.3",
     "log-symbols": "^2.2.0",
     "metalsmith": "^2.3.0",
     "metalsmith-discover-partials": "^0.1.0",
@@ -114,6 +120,7 @@
     "opn-cli": "^4.0.0",
     "perfy": "^1.1.2",
     "postcss-loader": "^3.0.0",
+    "prettier": "^1.16.4",
     "purify-css": "^1.2.5",
     "purifycss-webpack": "^0.7.0",
     "sass-loader": "^7.1.0",
@@ -147,7 +154,14 @@
   },
   "husky": {
     "hooks": {
-      "post-merge": "npm install"
+      "post-merge": "npm install",
+      "pre-commit": "lint-staged"
     }
+  },
+  "lint-staged": {
+    "*.{js,json,scss}": [
+      "npm run prettier:write",
+      "git add"
+    ]
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = ({file, options, env}) => ({
+module.exports = ({ file, options, env }) => ({
 	plugins: {
 		autoprefixer: options.autoprefixer,
 		/**

--- a/src/app/base/base.js
+++ b/src/app/base/base.js
@@ -20,8 +20,7 @@ export function ieViewportFix() {
  */
 export function consoleErrorFix() {
 	let method;
-	const noOp = function () {
-	};
+	const noOp = function() {};
 
 	const methods = [
 		'assert',

--- a/src/app/base/polyfills.js
+++ b/src/app/base/polyfills.js
@@ -33,7 +33,6 @@ import 'promise-polyfill/src/polyfill';
  */
 
 export const applyPolyfills = () => {
-
 	const polyfills = [];
 
 	/**

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -10,10 +10,10 @@ import 'bootstrap';
 // import 'bootstrap/js/dist/dropdown';
 
 // Import polyfills
-import {applyPolyfills} from './base/polyfills';
+import { applyPolyfills } from './base/polyfills';
 
 // Import methods from the base module
-import {consoleErrorFix, ieViewportFix} from './base/base';
+import { consoleErrorFix, ieViewportFix } from './base/base';
 
 // Import our Sass entrypoint to create the CSS app bundle
 import '../assets/scss/index.scss';

--- a/src/assets/scss/_print.scss
+++ b/src/assets/scss/_print.scss
@@ -16,7 +16,7 @@
 		color: #404040;
 	}
 
-	[role="navigation"],
+	[role='navigation'],
 	aside,
 	img,
 	nav {

--- a/src/assets/scss/_theme.scss
+++ b/src/assets/scss/_theme.scss
@@ -1,14 +1,14 @@
 // Override and extend Bootstrap stuff
 // --------------------------------------------------
 // Files, classes, mixins etc.
-@import "theme/mixins";
-@import "theme/scaffolding";
-@import "theme/alerts";
+@import 'theme/mixins';
+@import 'theme/scaffolding';
+@import 'theme/alerts';
 
 // Own modules
 // --------------------------------------------------
 // @import "theme/testResponsiveHelpers"; // debug
-@import "theme/footer";
+@import 'theme/footer';
 
 // Important note //
 // You could also use this file to insert theme related style definitions

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -12,21 +12,19 @@
 //			font-size: @font-size-base - 1;
 //		}
 //	}
-$retina: "(-webkit-min-device-pixel-ratio: 1.5)",
-	"(min--moz-device-pixel-ratio: 1.5)",
-	"(-o-min-device-pixel-ratio: 3/2)",
-	"(min-device-pixel-ratio: 1.5)";
-$xs-only: "only screen and (max-width: $screen-xs-max)";
-$sm-only: "only screen and (min-width: $screen-xs-min) and (max-width: $screen-sm-max)";
-$md-only: "only screen and (min-width: $screen-sm-min) and (max-width: $screen-md-max)";
-$lg-only: "only screen and (min-width: $screen-md-min) and (max-width: $screen-lg)";
-$sm-and-below: "only screen and (max-width: $screen-xs-max)";
-$md-and-below: "only screen and (max-width: $screen-sm-max)";
-$lg-and-below: "only screen and (max-width: $screen-lg-min)";
-$sm-and-above: "only screen and (min-width: $screen-xs-min)";
-$md-and-above: "only screen and (min-width: $screen-sm-min)";
-$lg-and-above: "only screen and (min-width: $screen-md-min)";
-$xl-and-above: "only screen and (min-width: $screen-lg-min)";
+$retina: '(-webkit-min-device-pixel-ratio: 1.5)', '(min--moz-device-pixel-ratio: 1.5)',
+	'(-o-min-device-pixel-ratio: 3/2)', '(min-device-pixel-ratio: 1.5)';
+$xs-only: 'only screen and (max-width: $screen-xs-max)';
+$sm-only: 'only screen and (min-width: $screen-xs-min) and (max-width: $screen-sm-max)';
+$md-only: 'only screen and (min-width: $screen-sm-min) and (max-width: $screen-md-max)';
+$lg-only: 'only screen and (min-width: $screen-md-min) and (max-width: $screen-lg)';
+$sm-and-below: 'only screen and (max-width: $screen-xs-max)';
+$md-and-below: 'only screen and (max-width: $screen-sm-max)';
+$lg-and-below: 'only screen and (max-width: $screen-lg-min)';
+$sm-and-above: 'only screen and (min-width: $screen-xs-min)';
+$md-and-above: 'only screen and (min-width: $screen-sm-min)';
+$lg-and-above: 'only screen and (min-width: $screen-md-min)';
+$xl-and-above: 'only screen and (min-width: $screen-lg-min)';
 
 // Bootstrap variables
 // --------------------------------------------------
@@ -39,12 +37,10 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 //
 // stylelint-disable max-empty-lines
 
-
 // Variables
 //
 // Variables should follow the `$component-state-property-size` formula for
 // consistent naming. Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.
-
 
 //
 // Color system
@@ -149,7 +145,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $enable-grid-classes:       true !default;
 // $enable-print-styles:       true !default;
 
-
 // Spacing
 //
 // Control the default styling of most Bootstrap elements by modifying these
@@ -200,7 +195,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 
 // $paragraph-margin-bottom:   1rem !default;
 
-
 // Grid breakpoints
 //
 // Define the minimum dimensions at which your layout will change,
@@ -217,7 +211,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // @include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
 // @include _assert-starts-at-zero($grid-breakpoints);
 
-
 // Grid containers
 //
 // Define the maximum width of `.container` for different screen sizes.
@@ -230,7 +223,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // ) !default;
 
 // @include _assert-ascending($container-max-widths, "$container-max-widths");
-
 
 // Grid columns
 //
@@ -261,7 +253,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $transition-base:             all .2s ease-in-out !default;
 // $transition-fade:             opacity .15s linear !default;
 // $transition-collapse:         height .35s ease !default;
-
 
 // Fonts
 //
@@ -334,7 +325,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 
 // $hr-margin-y:                 $spacer !default;
 
-
 // Tables
 //
 // Customizes the `.table` component with basic values, each used across all table variations.
@@ -359,7 +349,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $table-dark-border-color:     lighten($gray-900, 7.5%) !default;
 // $table-dark-color:            $body-bg !default;
 
-
 // Buttons + Forms
 //
 // Shared variables that are reassigned to `$input-` and `$btn-` specific variables.
@@ -381,7 +370,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $input-btn-line-height-lg:    $line-height-lg !default;
 
 // $input-btn-border-width:      $border-width !default;
-
 
 // Buttons
 //
@@ -418,7 +406,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $btn-border-radius-sm:        $border-radius-sm !default;
 
 // $btn-transition:              color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
-
 
 // Forms
 
@@ -559,13 +546,11 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 //   en: "Browse"
 // ) !default;
 
-
 // Form validation
 // $form-feedback-margin-top:          $form-text-margin-top !default;
 // $form-feedback-font-size:           $small-font-size !default;
 // $form-feedback-valid-color:         theme-color("success") !default;
 // $form-feedback-invalid-color:       theme-color("danger") !default;
-
 
 // Dropdowns
 //
@@ -594,7 +579,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $dropdown-item-padding-x:           1.5rem !default;
 
 // $dropdown-header-color:             $gray-600 !default;
-
 
 // Z-index master list
 //
@@ -688,12 +672,10 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $pagination-disabled-bg:            $white !default;
 // $pagination-disabled-border-color:  $gray-300 !default;
 
-
 // Jumbotron
 
 // $jumbotron-padding:                 2rem !default;
 // $jumbotron-bg:                      $gray-200 !default;
-
 
 // Cards
 
@@ -715,7 +697,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $card-columns-gap:                  1.25rem !default;
 // $card-columns-margin:               $card-spacer-y !default;
 
-
 // Tooltips
 
 // $tooltip-font-size:           $font-size-sm !default;
@@ -731,7 +712,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $tooltip-arrow-width:         .8rem !default;
 // $tooltip-arrow-height:        .4rem !default;
 // $tooltip-arrow-color:         $tooltip-bg !default;
-
 
 // Popovers
 
@@ -758,7 +738,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 
 // $popover-arrow-outer-color:         fade-in($popover-border-color, .05) !default;
 
-
 // Badges
 
 // $badge-font-size:                   75% !default;
@@ -771,7 +750,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // Use a higher than normal value to ensure completely rounded edges when
 // customizing padding or font-size on labels.
 // $badge-pill-border-radius:          10rem !default;
-
 
 // Modals
 
@@ -803,7 +781,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 
 // $modal-transition:                  transform .3s ease-out !default;
 
-
 // Alerts
 //
 // Define alert colors, border radius, and padding.
@@ -818,7 +795,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $alert-bg-level:                    -10 !default;
 // $alert-border-level:                -9 !default;
 // $alert-color-level:                 6 !default;
-
 
 // Progress bars
 
@@ -856,7 +832,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $list-group-action-active-color:    $body-color !default;
 // $list-group-action-active-bg:       $gray-200 !default;
 
-
 // Image thumbnails
 
 // $thumbnail-padding:                 .25rem !default;
@@ -866,12 +841,10 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $thumbnail-border-radius:           $border-radius !default;
 // $thumbnail-box-shadow:              0 1px 2px rgba($black, .075) !default;
 
-
 // Figures
 
 // $figure-caption-font-size:          90% !default;
 // $figure-caption-color:              $gray-600 !default;
-
 
 // Breadcrumbs
 
@@ -885,7 +858,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 // $breadcrumb-divider-color:          $gray-600 !default;
 // $breadcrumb-active-color:           $gray-600 !default;
 // $breadcrumb-divider:                "/" !default;
-
 
 // Carousel
 
@@ -908,7 +880,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 
 // $carousel-transition:               transform .6s ease !default;
 
-
 // Close
 
 // $close-font-size:                   $font-size-base * 1.5 !default;
@@ -929,7 +900,6 @@ $xl-and-above: "only screen and (min-width: $screen-lg-min)";
 
 // $pre-color:                         $gray-900 !default;
 // $pre-scrollable-max-height:         340px !default;
-
 
 // Printing
 // $print-page-size:                   a3 !default;

--- a/src/assets/scss/index.scss
+++ b/src/assets/scss/index.scss
@@ -1,9 +1,9 @@
 // Import our variables to override Bootstraps default ones
-@import "./variables";
+@import './variables';
 
 // Bootstrap Core
 // --------------------------------------------------
-@import "../../../node_modules/bootstrap/scss/bootstrap";
+@import '../../../node_modules/bootstrap/scss/bootstrap';
 
 // Or import only what you need to keep your vendor bundle small
 // See "../../../node_modules/bootstrap/scss/bootstrap" for available files
@@ -23,7 +23,7 @@
 
 // Theme
 // --------------------------------------------------
-@import "./theme";
+@import './theme';
 
 // Print Styles
 // --------------------------------------------------

--- a/src/assets/scss/theme/_footer.scss
+++ b/src/assets/scss/theme/_footer.scss
@@ -27,7 +27,6 @@ $footer-text-margin: 20px;
 // Module wrapper
 
 .footer {
-
 	// Local variables
 	//
 	// Which are meant to be used only in this module. »Global« variables are stored

--- a/src/assets/scss/theme/_scaffolding.scss
+++ b/src/assets/scss/theme/_scaffolding.scss
@@ -1,4 +1,4 @@
-@import "footer";
+@import 'footer';
 
 //
 // Scaffolding
@@ -11,11 +11,21 @@
 // Fix viewport issues with IE 10.
 // See http://getbootstrap.com/getting-started/#support-ie10-width
 // stylelint-disable at-rule-empty-line-before
-@-webkit-viewport { width: device-width; }
-@-moz-viewport { width: device-width; }
-@-ms-viewport { width: device-width; }
-@-o-viewport { width: device-width; }
-@viewport { width: device-width; }
+@-webkit-viewport {
+	width: device-width;
+}
+@-moz-viewport {
+	width: device-width;
+}
+@-ms-viewport {
+	width: device-width;
+}
+@-o-viewport {
+	width: device-width;
+}
+@viewport {
+	width: device-width;
+}
 // stylelint-enable
 
 html {

--- a/src/assets/scss/theme/_testResponsiveHelpers.scss
+++ b/src/assets/scss/theme/_testResponsiveHelpers.scss
@@ -24,52 +24,52 @@ html::before {
 body {
 	&::after {
 		@media #{$retina} {
-			content: "undefined / retina";
+			content: 'undefined / retina';
 		}
 
 		@media #{$xs-only} {
-			content: "xs-only";
+			content: 'xs-only';
 			left: 0;
 			bottom: 0;
 
 			@media #{$retina} {
-				content: "xs-only / retina";
+				content: 'xs-only / retina';
 				left: 0;
 				bottom: 0;
 			}
 		}
 
 		@media #{$sm-only} {
-			content: "sm-only";
+			content: 'sm-only';
 			left: 0;
 			bottom: 0;
 
 			@media #{$retina} {
-				content: "sm-only / retina";
+				content: 'sm-only / retina';
 				left: 0;
 				bottom: 0;
 			}
 		}
 
 		@media #{$md-only} {
-			content: "md-only";
+			content: 'md-only';
 			left: 0;
 			bottom: 0;
 
 			@media #{$retina} {
-				content: "md-only / retina";
+				content: 'md-only / retina';
 				left: 0;
 				bottom: 0;
 			}
 		}
 
 		@media #{$lg-only} {
-			content: "lg-only";
+			content: 'lg-only';
 			left: 0;
 			bottom: 0;
 
 			@media #{$retina} {
-				content: "lg / retina";
+				content: 'lg / retina';
 				left: 0;
 				bottom: 0;
 			}
@@ -78,40 +78,40 @@ body {
 
 	&::before {
 		@media #{$retina} {
-			content: "undefined / retina";
+			content: 'undefined / retina';
 		}
 
 		@media #{$lg-and-below} {
-			content: "lg-and-below";
+			content: 'lg-and-below';
 			left: 0;
 			top: 0;
 
 			@media #{$retina} {
-				content: "lg-and-below / retina";
+				content: 'lg-and-below / retina';
 				left: 0;
 				top: 0;
 			}
 		}
 
 		@media #{$md-and-below} {
-			content: "md-and-below";
+			content: 'md-and-below';
 			left: 0;
 			top: 0;
 
 			@media #{$retina} {
-				content: "md-and-below / retina";
+				content: 'md-and-below / retina';
 				left: 0;
 				top: 0;
 			}
 		}
 
 		@media #{$sm-and-below} {
-			content: "sm-and-below";
+			content: 'sm-and-below';
 			left: 0;
 			top: 0;
 
 			@media #{$retina} {
-				content: "sm-and-below / retina";
+				content: 'sm-and-below / retina';
 				left: 0;
 				top: 0;
 			}
@@ -121,52 +121,52 @@ body {
 
 html::before {
 	@media #{$retina} {
-		content: "undefined / retina";
+		content: 'undefined / retina';
 	}
 
 	@media #{$sm-and-above} {
-		content: "sm-and-above";
+		content: 'sm-and-above';
 		right: 0;
 		bottom: 0;
 
 		@media #{$retina} {
-			content: "sm-and-above / retina";
+			content: 'sm-and-above / retina';
 			right: 0;
 			bottom: 0;
 		}
 	}
 
 	@media #{$md-and-above} {
-		content: "md-and-above";
+		content: 'md-and-above';
 		right: 0;
 		bottom: 0;
 
 		@media #{$retina} {
-			content: "md-and-above / retina";
+			content: 'md-and-above / retina';
 			right: 0;
 			bottom: 0;
 		}
 	}
 
 	@media #{$lg-and-above} {
-		content: "lg-and-above";
+		content: 'lg-and-above';
 		right: 0;
 		bottom: 0;
 
 		@media #{$retina} {
-			content: "lg-and-above / retina";
+			content: 'lg-and-above / retina';
 			right: 0;
 			bottom: 0;
 		}
 	}
 
 	@media #{$xl-and-above} {
-		content: "xl-and-above";
+		content: 'xl-and-above';
 		right: 0;
 		bottom: 0;
 
 		@media #{$retina} {
-			content: "xl-and-above / retina";
+			content: 'xl-and-above / retina';
 			right: 0;
 			bottom: 0;
 		}


### PR DESCRIPTION
We are using [prettier](https://prettier.io) to format JavaScript, JSON and SCSS files automatically before you commit your files to Git via a pre-commit hook.

The prettier settings are defined in `.prettierrc` in the project root. In case prettier is to opinated for you or you don’t want Prettier to change your files without the chance to review the changes you just have to delete the pre-commit hook with in the `package.json`:

```json
"husky": {
  "hooks": {
    "post-merge": "npm install",
    "pre-commit": "lint-staged"
  }
}
```

But we totally recommend you to give this workflow a chance, because it’s just one more thing you don’t have to care about.