### PR TITLE
revert fix: Initially lint files with npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "repository": "micromata/baumeister",
   "private": true,
   "scripts": {
-    "start": "npm-run-all clean:dev handlebars --parallel handlebars:watch webpack:server eslint eslint:watch stylelint stylelint:watch --silent",
+    "start": "npm-run-all clean:dev handlebars --parallel handlebars:watch webpack:server eslint:watch stylelint:watch --silent",
     "build": "npm-run-all test handlebars clean webpack --silent",
     "build:dev": "npm-run-all test handlebars clean:dev webpack:dev --silent",
     "build:serve": "npm-run-all --parallel build:serve:*",


### PR DESCRIPTION
This reverts commit 57d13745364ee92c657c16685b127e9770fab3a8.

The lack of initially linting files with npm start was on purpose. Because it’s frustrating when you aren’t abel to start because of linting errors.